### PR TITLE
fix(push): push with no wait-channels no longer sends an empty string

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -89,9 +89,17 @@ workflows:
           org: prodvana-cont-testing-prod
           service: orb-test
           docker-image: "index.docker.io/prodvana/demo_api:v4"
-          wait-channels: staging
           requires:
             - command-tests
+      - prodvana/push:
+          name: test-push-wait-job
+          filters: *filters
+          org: prodvana-cont-testing-prod
+          service: orb-test
+          docker-image: "index.docker.io/prodvana/demo_api:v4"
+          wait-channels: staging
+          requires:
+            - test-push-job
       - prodvana/push:
           name: test-push-multiprogram-job
           filters: *filters
@@ -109,6 +117,7 @@ workflows:
           pub-type: production
           requires:
             - test-push-job
+            - test-push-wait-job
             - test-push-multiprogram-job
             - orb-tools/pack
             - command-tests

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -4,9 +4,10 @@ set -euxo pipefail
 # Evaluate env vars in image name
 PARAM_DOCKER_IMAGE=$(eval echo "${PARAM_DOCKER_IMAGE}")
 
-ADDL_FLAGS=""
+CMD="pvnctl services update-images ${PARAM_SERVICE} --image ${PARAM_DOCKER_IMAGE}"
 if [[ -n ${PARAM_WAIT_CHANNELS} ]]; then
-	ADDL_FLAGS="--wait-channel=\"${PARAM_WAIT_CHANNELS}\""
+    CMD="$CMD --wait-channel=${PARAM_WAIT_CHANNELS}"
 fi
+
 pvnctl auth context use "${PARAM_AUTH_CONTEXT}"
-pvnctl services update-images "${PARAM_SERVICE}" --image "${PARAM_DOCKER_IMAGE}" "${ADDL_FLAGS}"
+eval "${CMD}"


### PR DESCRIPTION
Due to how the wait-channels optional arg was being quoted, pvnctl would
recieve an extra (empty) argument
